### PR TITLE
feature: added in "forcers232" config value

### DIFF
--- a/src/SonyBraviaConfig.cs
+++ b/src/SonyBraviaConfig.cs
@@ -10,5 +10,6 @@ namespace SonyBraviaEpi
 
         public long? WarmingTimeMs { get; set; }
         public long? CoolingTimeMs { get; set; }
+        public bool ForceRs232 { get; set; }
     }
 }

--- a/src/SonyBraviaDevice.cs
+++ b/src/SonyBraviaDevice.cs
@@ -63,7 +63,7 @@ namespace SonyBraviaEpi
 
             _coms = comms;
             var socket = _coms as ISocketStatus;
-            _comsIsRs232 = socket == null;
+            _comsIsRs232 = socket == null || props.ForceRs232;
             if (_comsIsRs232)
             {
                 _queueRs232 = new CrestronQueue<byte[]>(50);


### PR DESCRIPTION
- tells the devices its rs232 in case of global cache or moxa endpoint